### PR TITLE
Added wildcard search for device name, and updated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,25 @@
 A small repo that allows the Thrustmaster TPR rudders to work with Elite Dangerous under Steam Proton.
 
 Build:
-```./make.sh```
+```
+./make.sh
+```
 
 Install:
-```sudo ./install.sh```
+```
+sudo ./install.sh
+```
 
 Uninstall:
-```sudo ./uninstall.sh```
+```
+sudo ./uninstall.sh
+```
 
 If it errors with "Too many Thrustmaster T-Pendular-Rudder devices detected." try the following in a terminal:
 
-```ls /dev/input/by-id/```
+```
+ls /dev/input/by-id/
+```
 
 Then with the name, you need to update ./src/protontpr.cpp line 57:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ProtonTPR
 A small repo that allows the Thrustmaster TPR rudders to work with Elite Dangerous under Steam Proton.
 
+## Installation
 Build:
 ```
 ./make.sh
@@ -16,6 +17,7 @@ Uninstall:
 sudo ./uninstall.sh
 ```
 
+## Troubleshooting
 If it errors with "Too many Thrustmaster T-Pendular-Rudder devices detected." try the following in a terminal:
 
 ```
@@ -37,4 +39,4 @@ sudo ./uninstall.sh
 sudo ./install.sh
 ```
 
-Instead of searching, it'll just look for your particular TPR device name.
+Instead of searching, it'll look for your particular TPR device name.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,31 @@
 A small repo that allows the Thrustmaster TPR rudders to work with Elite Dangerous under Steam Proton.
 
 Build:
-./make.sh
+```./make.sh```
 
 Install:
-sudo ./install.sh
+```sudo ./install.sh```
 
 Uninstall:
+```sudo ./uninstall.sh```
+
+If it errors with "Too many Thrustmaster T-Pendular-Rudder devices detected." try the following in a terminal:
+
+```ls /dev/input/by-id/```
+
+Then with the name, you need to update ./src/protontpr.cpp line 57:
+
+```    const char* realTprDevicePath = findRealTprDevicePath();```
+
+Update it to:
+
+```    const char* realTprDevicePath = "Name of your TPR device you found";```
+
+Then run:
+```
 sudo ./uninstall.sh
+./make.sh
+sudo ./install.sh
+```
+
+Instead of searching, it'll just look for your particular TPR device name.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A small repo that allows the Thrustmaster TPR rudders to work with Elite Dangerous under Steam Proton.
 
 ## Installation
+
 Build:
 ```
 ./make.sh
@@ -18,6 +19,7 @@ sudo ./uninstall.sh
 ```
 
 ## Troubleshooting
+
 If it errors with "Too many Thrustmaster T-Pendular-Rudder devices detected." try the following in a terminal:
 
 ```


### PR DESCRIPTION
When running it against my system the hardcoded device name wasn't correct.

Modifying it worked, so to make it more future proof, added in a search for it instead, using the common start of the device name.

I also took the liberty of updating the readme, and added some troubleshooting steps, code blocks to be able to click to copy/paste etc.