### PR TITLE
Adding Github Actions

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies for extraction
-      if: input.package_manager == 'apt'
+      if: inputs.package_manager == 'apt'
       shell: bash
       run: |
         sudo apt-get update

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -32,5 +32,5 @@ runs:
       shell: bash
       run: |
         sudo cp -r libevdev_pkg/extracted_libevdev/usr/include/libevdev-1.0/* /usr/local/include/
-        sudo cp libevdev_pkg/extracted_libevdev/usr/lib/* /lib/
+        sudo cp -r libevdev_pkg/extracted_libevdev/usr/lib/* /lib/
         sudo ldconfig

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -32,5 +32,5 @@ runs:
       shell: bash
       run: |
         sudo cp -r libevdev_pkg/extracted_libevdev/usr/include/libevdev-1.0/* /usr/local/include/
-        sudo cp libevdev_pkg/extracted_libevdev/usr/lib/x86_64-linux-gnu/* /usr/local/lib/
+        sudo cp libevdev_pkg/extracted_libevdev/usr/lib/* /lib/
         sudo ldconfig

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -1,0 +1,17 @@
+name: Setup Environment
+
+inputs:
+  package_manager:
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential libevdev-dev

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -8,9 +8,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -8,8 +8,29 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install dependencies
+    - name: Install dependencies for extraction
+      if: input.package_manager == 'apt'
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential libevdev-dev
+        sudo apt-get install -y dpkg-dev gnu-tar
+
+    - name: Download libevdev-dev package
+      shell: bash
+      run: |
+        mkdir -p libevdev_pkg
+        cd libevdev_pkg
+        apt-get download libevdev-dev
+
+    - name: Extract libevdev-dev package
+      shell: bash
+      run: |
+        cd libevdev_pkg
+        dpkg-deb -x *.deb extracted_libevdev
+
+    - name: Move files to appropriate directories
+      shell: bash
+      run: |
+        sudo cp -r libevdev_pkg/extracted_libevdev/usr/include/libevdev-1.0/* /usr/local/include/
+        sudo cp libevdev_pkg/extracted_libevdev/usr/lib/x86_64-linux-gnu/* /usr/local/lib/
+        sudo ldconfig

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y dpkg-dev gnu-tar
+        sudo apt-get install -y dpkg-dev
 
     - name: Download libevdev-dev package
       shell: bash

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -9,6 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
+      shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y build-essential libevdev-dev

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,7 +4,6 @@ on:
   - push
   - pull_request
 
-
 jobs:
   build:
 
@@ -33,7 +32,7 @@ jobs:
       - name: Compile C++ code
         shell: bash
         run: |
-          g++ -o protontpr src/protontpr.cpp -levdev
+          g++ -o protontpr src/protontpr.cpp -I/usr/local/include/libevdev-1.0 -L/usr/local/lib -levdev
           echo "Compilation finished successfully."
 
       # - name: Run tests (optional)
@@ -44,5 +43,5 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: protontpr-binary-${{ matrix.os }}
+          name: protontpr-binary-${{ matrix.os.name }}
           path: ./protontpr

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,6 +22,9 @@ jobs:
             package_manager: apt
     runs-on: ${{ matrix.os['runs-on'] }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Compile C++ code
         shell: bash
         run: |
-          g++ -o protontpr protontpr.cpp -levdev
+          g++ -o protontpr src/protontpr.cpp -levdev
           echo "Compilation finished successfully."
 
       # - name: Run tests (optional)

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Compile C++ code
         shell: bash
         run: |
-          g++ -o protontpr src/protontpr.cpp -I/usr/local/include/libevdev-1.0 -L/lib -levdev
+          g++ -std=c++17 -o protontpr src/protontpr.cpp -I/usr/local/include/libevdev-1.0 -L/lib -levdev
           echo "Compilation finished successfully."
 
       # - name: Run tests (optional)

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Compile C++ code
         shell: bash
         run: |
-          g++ -o protontpr src/protontpr.cpp -I/usr/local/include/libevdev-1.0 -L/usr/local/lib -levdev
+          g++ -o protontpr src/protontpr.cpp -I/usr/local/include/libevdev-1.0 -L/lib -levdev
           echo "Compilation finished successfully."
 
       # - name: Run tests (optional)

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,10 +3,10 @@ name: Build and Test
 on:
   push:
     branches:
-      - main
+      - **
   pull_request:
     branches:
-      - main
+      - **
 
 jobs:
   build:
@@ -16,13 +16,13 @@ jobs:
         os:
           - name: ubuntu-beta
             runs-on: ubuntu-24.04
-            package_manager: apt-get
+            package_manager: apt
           - name: ubuntu-latest
             runs-on: ubuntu-latest
-            package_manager: apt-get
+            package_manager: apt
           - name: ubuntu-old
             runs-on: ubuntu-20.04
-            package_manager: apt-get
+            package_manager: apt
     runs-on: ${{ matrix.os['runs-on'] }}
     steps:
       - name: Setup Environment

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,12 +1,9 @@
 name: Build and Test
 
 on:
-  push:
-    branches:
-      - **
-  pull_request:
-    branches:
-      - **
+  - push
+  - pull_request
+
 
 jobs:
   build:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Environment
-        uses: ./.github/actions/setup-environment
+        uses: ./.github/actions/setup_environment
         with:
           package_manager: ${{ matrix.os.package_manager }}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,7 @@ jobs:
           package_manager: ${{ matrix.os.package_manager }}
 
       - name: Compile C++ code
+        shell: bash
         run: |
           g++ -o protontpr protontpr.cpp -levdev
           echo "Compilation finished successfully."

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,47 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os:
+          - name: ubuntu-beta
+            runs-on: ubuntu-24.04
+            package_manager: apt-get
+          - name: ubuntu-latest
+            runs-on: ubuntu-latest
+            package_manager: apt-get
+          - name: ubuntu-old
+            runs-on: ubuntu-20.04
+            package_manager: apt-get
+    runs-on: ${{ matrix.os['runs-on'] }}
+    steps:
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+        with:
+          package_manager: ${{ matrix.os.package_manager }}
+
+      - name: Compile C++ code
+        run: |
+          g++ -o protontpr protontpr.cpp -levdev
+          echo "Compilation finished successfully."
+
+      # - name: Run tests (optional)
+      #   run: |
+      #     ./protontpr --test
+      #     echo "Tests completed successfully."
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: protontpr-binary-${{ matrix.os }}
+          path: ./protontpr

--- a/src/protontpr.cpp
+++ b/src/protontpr.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <fcntl.h>
 #include <string.h>
+#include <unistd.h> // For close and usleep
 #include <libevdev/libevdev.h>
 #include <libevdev/libevdev-uinput.h>
 


### PR DESCRIPTION
It's set to compile on Ubuntu 20.04, 22.04, 24.04

I've also had to make this change:

```
#include <unistd.h> // For close and usleep
```
To the protontpr.cpp for compilation on 20.04.
I also had to enable static linking, which boosts the compilation size a little.

I'm not going back any further on Ubuntu versions because GH Actions doesn't have it by default.

Ideally future setup is that we could add other non-debian OS's, and use containers on the runner to compile them.  Means that we could do away with the local compilation requirement