### PR TITLE
Properly handle `EAGAIN` and `EWOULDBLOCK`

### DIFF
--- a/src/protontpr.cpp
+++ b/src/protontpr.cpp
@@ -220,14 +220,14 @@ int main(int argc, char** argv) {
 			}
 			
 			// If the return code is negative, we can assume the real device is gone.
-			if (rc < 0) {
+			if (rc < 0 && rc != -EAGAIN && rc != -EWOULDBLOCK) {
 				std::cerr << "In use Thrustmaster T-Pendular-Rudder device " << realTprDevicePath << " returns " << rc << " on read, resetting." << std::endl;
 				closeRealTPRDevice(realTprFd, realTprDevice);
 			}
 		}
 	
 		// Sleep 1ms if there is nothing to do
-		if (rc == -EAGAIN) {
+		if (rc == -EAGAIN || rc == -EWOULDBLOCK) {
 			usleep(1000);
 		}
 	}


### PR DESCRIPTION
Previously, they would be treated as an error and lead to device being reopened.

usbip is constantly using `EWOULDBLOCK`, and, real device being attached over network, this was leading to constant spam in the logs and non-working virtual device.